### PR TITLE
[isExample] Step1-1 index.html 응답

### DIFF
--- a/src/main/java/webserver/HttpRequest.java
+++ b/src/main/java/webserver/HttpRequest.java
@@ -10,7 +10,7 @@ public class HttpRequest {
 
     private String body;
 
-    public void setHttpRequest(String method, String path, String protocolVersion, Map<String, String> headers, String body) {
+    public HttpRequest(String method, String path, String protocolVersion, Map<String, String> headers, String body) {
         this.method = method;
         this.path = path;
         this.protocolVersion = protocolVersion;

--- a/src/main/java/webserver/HttpRequest.java
+++ b/src/main/java/webserver/HttpRequest.java
@@ -1,0 +1,41 @@
+package webserver;
+
+import java.util.Map;
+
+public class HttpRequest {
+    private String method;
+    private String path;
+    private String protocolVersion;
+    private Map<String, String> headers;
+
+    private String body;
+
+    public void setHttpRequest(String method, String path, String protocolVersion, Map<String, String> headers, String body) {
+        this.method = method;
+        this.path = path;
+        this.protocolVersion = protocolVersion;
+        this.headers = headers;
+        this.body = body;
+    }
+
+    public String getMethod(){
+        return method;
+    }
+
+    public String getPath(){
+        return path;
+    }
+
+    public String getProtocolVersion(){
+        return protocolVersion;
+    }
+
+    public Map<String, String> getHeaders(){
+        return headers;
+    }
+
+    public String getBody(){
+        return body;
+    }
+
+}

--- a/src/main/java/webserver/HttpRequestParser.java
+++ b/src/main/java/webserver/HttpRequestParser.java
@@ -1,0 +1,48 @@
+package webserver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpRequestParser {
+
+    public HttpRequest parse(InputStream inputStream) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        String requestLine = br.readLine();
+
+        String[] requestParts = requestLine.split(" ");
+        String method = requestParts[0];
+        String path = requestParts[1];
+        String protocolVersion = requestParts[2];
+
+        Map<String, String> headers = parseHeaders(br);
+        String body = parseBody(br, headers);
+
+        return new HttpRequest(method, path, protocolVersion, headers, body);
+    }
+
+    private Map<String, String> parseHeaders(BufferedReader br) throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        String headerLine;
+        while (!(headerLine = br.readLine()).isEmpty()) {
+            String[] headerParts = headerLine.split(": ");
+            headers.put(headerParts[0], headerParts[1]);
+        }
+        return headers;
+    }
+
+    private String parseBody(BufferedReader br, Map<String, String> headers) throws IOException {
+        StringBuilder body = new StringBuilder();
+        if (headers.containsKey("Content-Length")) {
+            int contentLength = Integer.parseInt(headers.get("Content-Length"));
+            for (int i = 0; i < contentLength; i++) {
+                body.append((char) br.read());
+            }
+        }
+        return body.toString();
+    }
+}

--- a/src/main/java/webserver/HttpResponse.java
+++ b/src/main/java/webserver/HttpResponse.java
@@ -1,0 +1,55 @@
+package webserver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpResponse {
+    private static final String HTTP_VERSION = "HTTP/1.1";
+    private final int statusCode;
+    private String statusText;
+    private Map<String, String> headers = new HashMap<>();
+    private byte[] body;
+
+    public HttpResponse(int statusCode){
+        this.statusCode = statusCode;
+        setStatusText(statusCode);
+    }
+
+    public void addHeader(String key, String value) {
+        headers.put(key, value);
+    }
+
+    public void setStatusText(int statusCode) {
+        switch (statusCode) {
+            case 200: statusText = "OK";
+                break;
+            case 404: statusText = "Not Found";
+                break;
+            default: break;
+        }
+    }
+
+    public void setBody(byte[] body) {
+        this.body = body;
+    }
+
+    public String getHttpVersion(){
+        return HTTP_VERSION;
+    }
+
+    public int getStatusCode(){
+        return statusCode;
+    }
+
+    public String getStatusText(){
+        return statusText;
+    }
+
+    public Map<String, String> getHeaders(){
+        return headers;
+    }
+
+    public byte[] getBody(){
+        return body;
+    }
+}

--- a/src/main/java/webserver/HttpResponseBuilder.java
+++ b/src/main/java/webserver/HttpResponseBuilder.java
@@ -1,0 +1,23 @@
+package webserver;
+
+import java.nio.charset.StandardCharsets;
+
+public class HttpResponseBuilder {
+    private static final int SUCCESS_STATUS_CODE = 200;
+    private static final int ERROR_STATUS_CODE = 400;
+    public HttpResponse createSuccessResponse(byte[] body) {
+        HttpResponse response = new HttpResponse(SUCCESS_STATUS_CODE);
+        response.addHeader("Content-Type", "text/html;charset=utf-8");
+        response.addHeader("Content-Length", String.valueOf(body.length));
+        response.setBody(body);
+        return response;
+    }
+
+    public HttpResponse createErrorResponse(byte[] body) {
+        HttpResponse response = new HttpResponse(ERROR_STATUS_CODE);
+        response.addHeader("Content-Type", "text/plain;charset=utf-8");
+        response.addHeader("Content-Length", String.valueOf(body.length));
+        response.setBody(body);
+        return response;
+    }
+}

--- a/src/main/java/webserver/HttpResponseSender.java
+++ b/src/main/java/webserver/HttpResponseSender.java
@@ -1,0 +1,33 @@
+package webserver;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Map;
+
+public class HttpResponseSender {
+    public void sendResponse(HttpResponse response, DataOutputStream dos) throws IOException {
+        sendStatusLine(response, dos);
+        sendHeaders(response, dos);
+        sendBody(response, dos);
+    }
+
+    private void sendStatusLine(HttpResponse response, DataOutputStream dos) throws IOException {
+        int statusCode = response.getStatusCode();
+        dos.writeBytes(response.getHttpVersion() + " "  + response.getStatusCode() + " " + response.getStatusText() + "\r\n");
+    }
+
+    private void sendHeaders(HttpResponse response, DataOutputStream dos) throws IOException {
+        for (Map.Entry<String, String> header : response.getHeaders().entrySet()) {
+            dos.writeBytes(header.getKey() + ": " + header.getValue() + "\r\n");
+        }
+        dos.writeBytes("\r\n");
+    }
+
+    private void sendBody(HttpResponse response, DataOutputStream dos) throws IOException {
+        byte[] body = response.getBody();
+        if (body != null) {
+            dos.write(body, 0, body.length);
+            dos.flush();
+        }
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -51,17 +51,22 @@ public class RequestHandler implements Runnable {
     }
 
     private void requestLogging(HttpRequest httpRequest){
-        logger.debug("========== HTTP Request ==========");
-        logger.debug("Method: " + httpRequest.getMethod());
-        logger.debug("Path: " + httpRequest.getPath());
-        logger.debug("Protocol Version: " + httpRequest.getProtocolVersion());
+        StringBuilder logMessage = new StringBuilder();
+
+        logMessage.append("\n========== HTTP Request ==========\n");
+        logMessage.append("Method: ").append(httpRequest.getMethod()).append("\n");
+        logMessage.append("Path: ").append(httpRequest.getPath()).append("\n");
+        logMessage.append("Protocol Version: ").append(httpRequest.getProtocolVersion()).append("\n");
         if (httpRequest.getHeaders() != null) {
-            httpRequest.getHeaders().forEach((key, value) -> logger.debug("Header: {} = {}", key, value));
+            httpRequest.getHeaders().forEach((key, value) ->
+                    logMessage.append("Header: ").append(key).append(" = ").append(value).append("\n"));
         }
         if (!httpRequest.getBody().isEmpty()) {
-            logger.debug("Body: " + httpRequest.getBody());
+            logMessage.append("Body: ").append(httpRequest.getBody()).append("\n");
         }
-        logger.debug("==================================");
+        logMessage.append("==================================");
+
+        logger.debug(logMessage.toString());
     }
 
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,9 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,8 +23,21 @@ public class RequestHandler implements Runnable {
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
+            BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+            String requestHeaderLine = br.readLine();
+
+            String path = requestHeaderLine.split(" ")[1];
+            logger.debug("url path: " + path);
+
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
+            File file = new File("./src/main/resources/templates" + path);
+            byte[] body;
+
+            body = "Valid page is not found".getBytes(StandardCharsets.UTF_8);
+            if (file.exists() && !"/".equals(path)) {
+                body = Files.readAllBytes(file.toPath());
+            }
+
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -1,7 +1,10 @@
 package webserver;
 
+import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +12,7 @@ import org.slf4j.LoggerFactory;
 public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
     private static final int DEFAULT_PORT = 8080;
+    private static final int NUMBER_OF_THREADS = 20;
 
     public static void main(String args[]) throws Exception {
         int port = 0;
@@ -18,16 +22,20 @@ public class WebServer {
             port = Integer.parseInt(args[0]);
         }
 
+        ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
         try (ServerSocket listenSocket = new ServerSocket(port)) {
             logger.info("Web Application Server started {} port.", port);
 
             // 클라이언트가 연결될때까지 대기한다.
-            Socket connection;
-            while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+            while(true) {
+                Socket connection = listenSocket.accept();
+                executorService.execute(new RequestHandler(connection));
             }
+        } catch (IOException e) {
+            logger.error("Server Exception: ", e);
+        } finally {
+            executorService.shutdown(); // 서버 종료 시, 스레드 풀
         }
     }
 }


### PR DESCRIPTION
## 구현 내용
**1. 정적인 html 파일 응답(index.html)**

> http://localhost:8080/index.html 로 접속했을 때 src/main/resources/templates 디렉토리의 파일을 읽어 클라이언트에 응답한다.

- HTTP Request Header에서 path 추출
- 요청된 파일이 존재할 경우 파일을 읽어들여 응답
- 요청된 파일이 존재하지 않거나 루트 경로("/") 요청 시 사용자 정의 메시지 응답

**2.HTTP Request 로깅**

> 서버로__ 들어오는 HTTP Request의 내용을 읽고 적절하게 파싱해서 로거(log.debug)를 이용해 출력한다.

- Start Line에서 메서드, 경로, 프로토콜 버전을 별도의 필드로 구현
- 헤더의 복잡성과 일반적으로 Key:Value 형태임을 고려하여 Map 필드로 구현
- 요청 데이터를 포함하는 바디를 문자열 필드로 구현
- Request의 모든 필드를 로거를 통해 출력

**3. Concurrent 패키지 적용**

> 기존의 프로젝트는 Java Thread 기반으로 작성되어 있다. 이를 Concurrent 패키지를 사용하도록 변경한다.

- 클라이언트 연결이 수립될 때마다 RequestHandler 인스턴스를 스레드 풀에 제출
- 각 클라이언트 연결을 별도의 스레드에서 동시에 처리 가능

**4. OOP와 클린 코딩**

> 유지보수에 좋은 구조에 대해 고민하고 코드를 개선해 본다.

책임 분리: 기존의 RequestHandler 클래스는 HTTP 요청 파싱, 요청 처리, 응답 생성 등 여러 책임을 가짐
- 책임을 분리하기 위해 별도의 클래스를 생성하여 각각의 작업 분리

메서드 추출: 하나의 메소드가 너무 많은 작업을 수행함
- 각 메서드가 하나의 작업만 수행하도록 작은 단위의 메서드 추출

로깅 매커니즘 개선
- 멀티 스레딩으로 인한 로그 섞임 해결

## 고민 사항
**1. 전체적인 리팩토링**

이번 리팩토링 과정에서 가장 중점을 둔 부분은 클래스의 책임 분리였습니다. 명확하고 깔끔한 코드 구조를 위해 각 클래스가 담당하는 책임을 명확히 하고자 했습니다. 특히, HTTP 요청과 응답 처리 로직을 분리하고, 멀티스레드 처리를 개선하는 과정에서 각 클래스의 역할과 범위를 정의하는 데 시간을 많이 할애했습니다.

그러나, "적절한 책임 분리의 수준"에 대한 명확한 기준을 설정하는 것은 여전히 고민되는 부분입니다.  이번 PR에서는 이러한 균형을 찾기 위해 노력했지만, 아직 이상적인 해답을 찾지 못한 것 같습니다. step1-2, step1-3을 진행하며 구현 흐름에 따라 추가적인 수정을 진행할 것 같습니다.

**2. 싱글톤**
리팩토링 과정에서 HttpResponse와 HttpRequest와 관련된 여러 클래스들을 도입함에 따라 각 스레드마다 특정 객체들이 반복적으로 생성되게 되었습니다. 특히 ResponseBuilder나 ResponseSender와 같은 클래스들은 상태를 가지지 않는 유틸리티 클래스라 싱글톤으로 관리하는 것이 더 효율적일 것 같다는 생각을 했습니다.

그러나, 전역 상태로 전환한다는게 프로그램에 큰 영향이 있을 것 같아 어떤 것이 최선의 방법인지 아직 결론을 내리지 못했습니다. 이 부분 역시 다음 과제들을 진행하며 조금 더 고민해보려고 합니다.

## 기타
x